### PR TITLE
Integrate Fatmap Summit Links to Coordinates.vue

### DIFF
--- a/src/components/Coordinates.vue
+++ b/src/components/Coordinates.vue
@@ -386,6 +386,12 @@ export default {
           }
         },
         {
+          name: 'FatMap',
+          url: () => {
+            return `https://fatmap.com/adventures/@${this.latitude},${this.longitude},10000,-66,-12,satellite`
+          }
+        },
+        {
           name: 'SummitPost',
           url: () => {
             return `https://www.summitpost.org/object_list.php?object_type=1&distance_lat_1=${this.latitude}&distance_lon_1=${this.longitude}&map_1=1`


### PR DESCRIPTION
Fatmap.com is a freemium world-wide 3D mapping application popular with mountaineers. It is similar to Google Earth but includes integrated hiking route data and other useful features. I would like to suggest that Fatmap Summit links are added to SOTL.AS.

The map link URL structure is as follows (example for GW/NW-001 summit):

`https://fatmap.com/adventures/@53.0685,-4.07623,10000,-66,-12,satellite`

The first two parameters are the lat/long values. The remaining parameters specify the 3D positioning for the camera view.

The third parameter specifies the camera altitude in feet. In the example above this is fixed at 10,000ft however the optimum value for this parameter would be `(a*2)*3.28` where `a` is the summit altitude in metres. However I was not sure how to implement this calculation within the Vue code.